### PR TITLE
Disable resume button when outside geo-zone

### DIFF
--- a/RentalApp.jsx
+++ b/RentalApp.jsx
@@ -692,7 +692,12 @@ setCoordinates({ lat: allowedLat, lng: allowedLng });
             <div className="pt-2 flex gap-2 flex-wrap">
             <button
                 onClick={handlePause}
-                className="bg-yellow-500 hover:bg-yellow-600 text-white px-4 py-2 rounded-md text-sm shadow"
+                disabled={forcedPauseReason === "zone"}
+                className={`px-4 py-2 rounded-md text-sm shadow text-white ${
+                  forcedPauseReason === "zone"
+                    ? "bg-gray-400 cursor-not-allowed"
+                    : "bg-yellow-500 hover:bg-yellow-600"
+                }`}
                 >
                 {rental.isPaused ? "▶ Продолжить" : "⏸ Пауза"}
                 </button>


### PR DESCRIPTION
## Summary
- disable the pause/resume button when rental is paused due to zone violation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d8b45461083228416034280cd0453