### PR TITLE
Fix rental cost formatting

### DIFF
--- a/RentalApp.jsx
+++ b/RentalApp.jsx
@@ -416,13 +416,16 @@ setCoordinates({ lat: allowedLat, lng: allowedLng });
       }
   
       updateStatus("⏳ Подписание транзакции...");
-      const totalCost = parseFloat(equipment.pricePerSecond) * parseInt(rental.duration);
-  
+      const totalCost =
+        parseFloat(equipment.pricePerSecond) * parseInt(rental.duration);
+
+      // toString() may produce scientific notation for small values which
+      // parseEther cannot parse. Force a fixed-point representation.
       const tx = await window.contract.rent(
         parseInt(rental.duration),
         latE6,
         lonE6,
-        { value: parseEther(totalCost.toString()) }
+        { value: parseEther(totalCost.toFixed(18)) }
       );
 
       await tx.wait();


### PR DESCRIPTION
## Summary
- handle small numbers in rental payment calculation by using fixed-point formatting

## Testing
- `pre-commit` *(fails: `pre-commit` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501ac954b48322b261a5ad22ca329e